### PR TITLE
Fix reverse clipping of extra channels

### DIFF
--- a/OPSCEA.m
+++ b/OPSCEA.m
@@ -192,7 +192,7 @@ axislim=reshape(axl,1,6)+[-1 1 -1 1 -1 1]*perim; clear axl %Use the, to define t
 ns=unique( [find(badch);   find(isnan(mean(em,2)));   find(isnan(mean(d,2)))]  ); % bad channels: those that are pre-marked, or if NaNs in their coordinates or ICEEG data traces
 nns=true(nch,1); nns(ns)=0; %nns=find(nns); %consolidate bad channels and those with NaNs
 %remove data channels previously clipped at end. Only include that which has electrode coordinates (intracranial)
-if size(em,1)>size(d,1); nch=size(em,1); d(nch+1:end,:)=[]; LL(nch+1:end,:)=[]; nns(nch+1:end)=[]; ns(ns>size(em,1))=[]; 
+if size(em,1)<size(d,1); nch=size(em,1); d(nch+1:end,:)=[]; nns(nch+1:end)=[]; ns(ns>size(em,1))=[]; 
    fprintf(2, 'ALERT: Clipping off extra bad channel entries (make sure you have the right ICEEG and bad channel files loaded)\n');
 end
 


### PR DESCRIPTION
Addresses #6, clipping now happens only if the electrodematrix contains less channels than the recording (as it should).
Removed the early mention of the LL variable to avoid an error.